### PR TITLE
feat: performance improvement deriveInitialInput

### DIFF
--- a/src/helpers/deriveInitial.ts
+++ b/src/helpers/deriveInitial.ts
@@ -1,11 +1,14 @@
 export function deriveInitial(input: { [fieldId: string]: any }, defaultValue: any): { [fieldId: string]: any } {
   return Object.keys(input).reduce((acc: { [fieldId: string]: any }, key: string) => {
     if (Array.isArray(input[key])) {
-      return { ...acc, [key]: input[key].map((value: any) => deriveInitial(value, defaultValue)) }
+      acc[key] = input[key].map((value: any) => deriveInitial(value, defaultValue));
+      return acc;
     } else if (typeof input[key] === 'object') {
-      return { ...acc, [key]: deriveInitial(input[key], defaultValue) }
+      acc[key] = deriveInitial(input[key], defaultValue);
+      return acc;
     } else {
-      return { ...acc, [key]: defaultValue }
+      acc[key] = defaultValue;
+      return acc;
     }
-  }, {})
+  }, {});
 }


### PR DESCRIPTION
By mutating the accumulator in the reduce function we no longer copy the entire object which is quite expensive.

If you wish I can write a test displaying the difference in execution time.