### PR TITLE
(docs) - static typing

### DIFF
--- a/docs/components/form.md
+++ b/docs/components/form.md
@@ -28,6 +28,8 @@ Form is used to wrap your component, you can pass options in and that will resul
 - change: `(fieldId: string, value: any) => void` - A function used to manually change a fields value.
 - isDirty: `boolean` - Whether the field is dirty or not.
 
+For generics check the staticTyping chapter part.
+
 ## Example
 
 ```js

--- a/docs/components/useError.md
+++ b/docs/components/useError.md
@@ -10,7 +10,7 @@ This accepts one parameter and that's a `fieldId`, analogue to the `Field` compo
 
 In return it will offer you the error string or null.
 
-Example
+## Example
 
 ```javascript
 const MyErrorComponent = ({ fieldId }) => {

--- a/docs/components/useField.md
+++ b/docs/components/useField.md
@@ -10,6 +10,8 @@ This accepts one parameter and that's a `fieldId`, analogue to the `Field` compo
 
 In return it will offer you an array with the first element being an object of operations and the second being an object of information about the field
 
+## Properties
+
 First object:
 
 - onBlur: this indicates that the fieldId will be touched
@@ -24,7 +26,9 @@ Second object:
 - touched: a boolean indicating whether or not this field has been touched
 - value: the current value of this field
 
-Example
+For generics check the staticTyping chapter part.
+
+## Example
 
 ```javascript
 const StringField = ({ fieldId }) => {

--- a/docs/components/useFieldArray.md
+++ b/docs/components/useFieldArray.md
@@ -10,6 +10,8 @@ This accepts one parameter and that's a `fieldId`, analogue to the `FieldArray` 
 
 In return it will offer you an array with the first element being an object of operations and the second being an object of information about the field
 
+## Properties
+
 First object:
 
 - add
@@ -25,7 +27,9 @@ Second object:
 - error: an error string if there's an error present.
 - value: the current value of this field
 
-Example
+For generics check the staticTyping chapter part.
+
+## Example
 
 ```javascript
 const MyArray = ({ fieldId }) => {

--- a/docs/staticTyping.md
+++ b/docs/staticTyping.md
@@ -1,0 +1,22 @@
+---
+id: staticTyping
+title: Static Typing
+sidebar_label: Static Typing
+---
+
+## Form
+
+Form accepts a values generic, this is an object containing
+all the values of the field. This will be used to determine what
+the `validation` and `submit` will happen with.
+
+Example: `Form<{ name: string }>(options)(Component)`
+
+## Fields
+
+Both `useFieldArrray` and `useField` accept a generic
+type to determine what value they'll have and what
+they should expect for the onChange to call.
+
+Example: `useField<string>(fieldId)` will make the
+value a `string` and make the onChange expect a string.

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -17,8 +17,8 @@ export interface FieldProps {
 
 const defaultWatchables = ['disabled', 'className'];
 
-const FieldContainer: React.FC<FieldProps> = (
-  { component, fieldId, innerRef, watchableProps, ...rest },
+const FieldContainer = (
+  { component, fieldId, innerRef, watchableProps, ...rest }: FieldProps,
 ) => {
   if (process.env.NODE_ENV !== 'production' && !component) {
     throw new Error('The Field needs a "component" property to  function correctly.');

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -17,8 +17,8 @@ export interface FieldProps {
 
 const defaultWatchables = ['disabled', 'className'];
 
-const FieldContainer = (
-  { component, fieldId, innerRef, watchableProps, ...rest }: FieldProps,
+const FieldContainer: React.FC<FieldProps> = (
+  { component, fieldId, innerRef, watchableProps, ...rest },
 ) => {
   if (process.env.NODE_ENV !== 'production' && !component) {
     throw new Error('The Field needs a "component" property to  function correctly.');

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -41,7 +41,7 @@ const OptionsContainer = <Values extends object>({
       ]);
 
       const { 0: values, 1: setFieldValue, 2: setValuesState } = useState(() =>
-        mapPropsToValues ? mapPropsToValues(props) : initialValues
+        mapPropsToValues ? mapPropsToValues(props) : initialValues,
       );
 
       const { 0: touched, 1: touch, 2: setTouchedState } = useState(EMPTY_OBJ);
@@ -86,7 +86,7 @@ const OptionsContainer = <Values extends object>({
               if (onError) onError(e, setFormError);
             });
         },
-        [values]
+        [values],
       );
 
       React.useEffect(() => {
@@ -132,7 +132,7 @@ const OptionsContainer = <Values extends object>({
           validate: validateForm,
           values,
         }),
-        [formErrors, formError, isDirty, setFieldTouched, onChange, touched, validateForm, values]
+        [formErrors, formError, isDirty, setFieldTouched, onChange, touched, validateForm, values],
       );
 
       const comp = React.useMemo(
@@ -147,7 +147,7 @@ const OptionsContainer = <Values extends object>({
             {...props}
           />
         ),
-        [...passDownProps, formError, isSubmitting]
+        [...passDownProps, formError, isSubmitting],
       );
 
       return <Provider value={providerValue}>{comp}</Provider>;

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -6,7 +6,9 @@ export interface FieldOperations<T> {
   onBlur: () => void;
   onChange: (value: T) => void;
   onFocus: () => void;
-  setFieldValue: (fieldId: string, value: T) => void;
+  // TODO: this can maybe removed, I saw this as an escape hatch,
+  // to deal with cross-dependent fields.
+  setFieldValue: (fieldId: string, value: any) => void;
 }
 
 export interface FieldInformation<T> {
@@ -16,7 +18,7 @@ export interface FieldInformation<T> {
 }
 
 export default function useField<T = any>(
-  fieldId: string
+  fieldId: string,
 ): [FieldOperations<T>, FieldInformation<T>] {
   // Dev-check
   if (process.env.NODE_ENV !== 'production' && (!fieldId || typeof fieldId !== 'string')) {

--- a/src/useFieldArray.ts
+++ b/src/useFieldArray.ts
@@ -17,7 +17,7 @@ export interface FieldInformation<T> {
 }
 
 export default function useFieldArray<T = any>(
-  fieldId: string
+  fieldId: string,
 ): [FieldOperations<T>, FieldInformation<T>] {
   if (process.env.NODE_ENV !== 'production' && (!fieldId || typeof fieldId !== 'string')) {
     throw new Error('The FieldArray needs a valid "fieldId" property to  function correctly.');
@@ -37,7 +37,7 @@ export default function useFieldArray<T = any>(
         (element: T) => {
           setFieldValue(fieldId, [...value, element]);
         },
-        [value]
+        [value],
       ),
       insert: React.useCallback(
         (at: number, element: T) => {
@@ -45,7 +45,7 @@ export default function useFieldArray<T = any>(
           result.splice(at, 0, element);
           setFieldValue(fieldId, result);
         },
-        [value]
+        [value],
       ),
       move: React.useCallback(
         (from: number, to: number) => {
@@ -54,16 +54,16 @@ export default function useFieldArray<T = any>(
           result.splice(to, 0, value[from]);
           setFieldValue(fieldId, result);
         },
-        [value]
+        [value],
       ),
       remove: React.useCallback(
         (element: T | number) => {
           setFieldValue(
             fieldId,
-            value.filter(x => x !== (typeof element === 'number' ? value[element] : element))
+            value.filter(x => x !== (typeof element === 'number' ? value[element] : element)),
           );
         },
-        [value]
+        [value],
       ),
       replace: React.useCallback(
         (at: number, element: T) => {
@@ -71,7 +71,7 @@ export default function useFieldArray<T = any>(
           result[at] = element;
           setFieldValue(fieldId, result);
         },
-        [value]
+        [value],
       ),
       swap: React.useCallback(
         (from: number, to: number) => {
@@ -80,7 +80,7 @@ export default function useFieldArray<T = any>(
           result[to] = value[from];
           setFieldValue(fieldId, result);
         },
-        [value]
+        [value],
       ),
     },
     {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,6 +14,7 @@
       "components/useField",
       "components/useError",
       "components/useFieldArray"
-    ]
+    ],
+    "types": ["staticTyping"]
   }
 }


### PR DESCRIPTION
At this point it's pretty dry since I don't know what to write about it, it's all pretty obvious :D Might look into enabling generics for `Field` and `FieldArray` later. Also might look into the possibility of supplying a `Props` generic for `mapPropsToValues`.

It was not my intention to correct lint mistakes but `tslint:fix` was turned on in vscode. I should maybe convert the codebase to eslint/prettier.