### PR TITLE
docs: Update useFieldArray example to not have # of hooks rendered er…

### DIFF
--- a/docs/components/useFieldArray.md
+++ b/docs/components/useFieldArray.md
@@ -28,24 +28,26 @@ Second object:
 Example
 
 ```javascript
+const MyArrayElement = ({ fieldId, index }) => {
+  const [{ onChange, onBlur }, { value: fieldValue, touched, error: fieldError }] = useField(`${fieldId}[${index}]`);
+  return (
+    <div>
+      <input onChange={onChange} onBlur={onBlur} value={fieldValue} />
+      {touched && fieldError && <p>{fieldError}</p>}
+    </div>
+  )
+}
+
 const MyArray = ({ fieldId }) => {
   const [
-    {
-      add
-    },
+    { add },
     { value, error }
   ] = useFieldArray(fieldId);
 
   return (
     <React.Fragment>
       {value.map((object, i) => {
-        const [{ onChange, onBlur }, { value: fieldValue, touched, error: fieldError }] = useField(`${fieldId}[${i}]`);
-        return (
-          <div>
-            <input onChange={onChange} onBlur={onBlur} value={fieldValue} />
-            {touched && fieldError && <p>{fieldError}</p>}
-          </div>
-        )
+        <MyArrayElement key={i} index={i} fieldId={fieldId} />
       })}
       <Button onClick={add} label="add" />
     </React.Fragment>


### PR DESCRIPTION
…ror.

Currently in the documentation the example doesn't compile, as it's possible to render more / less hooks in the same component. Which isn't allowed by react.