### PR TITLE
(chore) - performant context propagation

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "tslint-react": "3.6.0",
     "typescript": "3.5.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "use-context-selector": "^0.2.0"
+  },
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"

--- a/src/Error.tsx
+++ b/src/Error.tsx
@@ -12,7 +12,7 @@ const ErrorContainer: React.FC<FieldProps> = ({ component, fieldId }) => {
     throw new Error('The ErrorMessage needs a "component" property to  function correctly.');
   }
   const error = useError(fieldId);
-  return React.useMemo(() => React.createElement(component, { error }), [error]);
+  return React.createElement(component, { error });
 };
 
 export default React.memo(ErrorContainer, () => true);

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -29,20 +29,14 @@ const FieldContainer: React.FC<FieldProps> = (
     1: { error, touched: isFieldTouched, value },
   } = useField(fieldId);
 
-  return React.useMemo(() =>
-    React.createElement(component, {
-      error,
-      ref: innerRef,
-      touched: isFieldTouched,
-      value,
-      ...actions,
-      ...rest,
-    }),
-    [
-      value, error, isFieldTouched,
-      ...((watchableProps || defaultWatchables).map((key: string) => rest[key])),
-    ],
-  );
+  return React.createElement(component, {
+    error,
+    ref: innerRef,
+    touched: isFieldTouched,
+    value,
+    ...actions,
+    ...rest,
+  });
 };
 
 export default React.memo(

--- a/src/FieldArray.tsx
+++ b/src/FieldArray.tsx
@@ -28,9 +28,7 @@ const FieldArrayContainer: React.FC<FieldProps> = (
     ...actions,
   };
 
-  return React.useMemo(() => component ?
-    React.createElement(component, props) :
-    render!(props), [value, error]);
+  return component ? React.createElement(component, props) : render!(props);
 };
 
 export default React.memo(FieldArrayContainer, () => true);

--- a/src/helpers/context.ts
+++ b/src/helpers/context.ts
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import { createContext } from 'use-context-selector';
 import { FormHookContext } from '../types';
 
-export const formContext = React.createContext<FormHookContext>({} as any);
+export const formContext = createContext<FormHookContext>({} as any);
 const { Provider } = formContext;
 export { Provider };

--- a/src/useError.ts
+++ b/src/useError.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { formContext } from './helpers/context';
 import { get } from './helpers/operations';
+import { FormHookContext } from './types';
 
 export interface FieldInformation {
   error: string;
@@ -10,9 +12,6 @@ export default function useError(fieldId: string): string | null {
   if (process.env.NODE_ENV !== 'production' && (!fieldId || typeof fieldId !== 'string')) {
     throw new Error('The Error needs a valid "fieldId" property to  function correctly.');
   }
-  const { errors } = React.useContext(formContext);
-  if (process.env.NODE_ENV !== 'production') {
-    React.useDebugValue(`${fieldId} Error: ${get(errors, fieldId)}`);
-  }
-  return React.useMemo(() => get(errors, fieldId), [errors]);
+  return useContextSelector(
+    formContext, ({ errors }: FormHookContext) => get(errors, fieldId));
 }

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { formContext } from './helpers/context';
 import { get } from './helpers/operations';
+import { FormHookContext } from './types';
 
 export interface FieldOperations<T> {
   onBlur: () => void;
@@ -16,20 +18,14 @@ export interface FieldInformation<T> {
 }
 
 export default function useField<T = any>(
-  fieldId: string
+  fieldId: string,
 ): [FieldOperations<T>, FieldInformation<T>] {
   // Dev-check
   if (process.env.NODE_ENV !== 'production' && (!fieldId || typeof fieldId !== 'string')) {
     throw new Error('The Field needs a valid "fieldId" property to  function correctly.');
   }
   // Context
-  const { errors, values, setFieldValue, setFieldTouched, touched } = React.useContext(formContext);
-
-  if (process.env.NODE_ENV !== 'production') {
-    React.useDebugValue(`${fieldId} Value: ${get(values, fieldId)}`);
-    React.useDebugValue(`${fieldId} Touched: ${get(touched, fieldId)}`);
-    React.useDebugValue(`${fieldId} Error: ${get(errors, fieldId)}`);
-  }
+  const { setFieldValue, setFieldTouched } = React.useContext(formContext);
 
   return [
     {
@@ -45,9 +41,12 @@ export default function useField<T = any>(
       setFieldValue,
     },
     {
-      error: React.useMemo(() => get(errors, fieldId), [errors]),
-      touched: React.useMemo(() => get(touched, fieldId), [touched]),
-      value: React.useMemo(() => get(values, fieldId) || '', [values]),
+      error: useContextSelector(
+        formContext, ({ errors }: FormHookContext) => get(errors, fieldId)),
+      touched: useContextSelector(
+        formContext, ({ touched }: FormHookContext) => get(touched, fieldId)),
+      value: useContextSelector(
+        formContext, ({ values }: FormHookContext) => get(values, fieldId) || ''),
     },
   ];
 }

--- a/src/useFormConnect.ts
+++ b/src/useFormConnect.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
+import { useContextSelector } from 'use-context-selector';
 import { formContext } from './helpers/context';
 import { FormHookContext } from './types';
 
-export default (): FormHookContext => React.useContext(formContext);
+export default (): FormHookContext => useContextSelector(formContext, form => form);

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -41,9 +41,9 @@
         "title": "Why",
         "sidebar_label": "Why"
       },
-      "utils/get": {
-        "title": "Get",
-        "sidebar_label": "Get"
+      "staticTyping": {
+        "title": "Static Typing",
+        "sidebar_label": "Static Typing"
       }
     },
     "links": {
@@ -53,7 +53,7 @@
       "philosophy": "philosophy",
       "components": "components",
       "hooks": "hooks",
-      "utilities": "utilities"
+      "types": "types"
     }
   },
   "pages-strings": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6581,6 +6581,11 @@ urlgrey@^0.4.4:
   resolved "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
   integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
+use-context-selector@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/use-context-selector/-/use-context-selector-0.2.0.tgz#d7423366fdaf7cd346b9c2a97df6ca8e10973a11"
+  integrity sha512-BTjtE+IF0Smfx98rhNZx5Y1whqWuR/oZZmKUEf14+0aTsQoZYDwBfaV4HE6nlfX3rtrjTRNOzY9WLqCh3hlMRw==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
Before I leave on vacation I decided to finish this up.

This is not mergeable yet since there  are some issues in `use-context-selector` that should be solved upstream. This being said this solution should increase bundle size by +- 600B.

Leaving hooked-form on 2.5KB which is still far behind other similar libraries, this SHOULD make this the fastest form library.

https://bundlephobia.com/result?p=use-context-selector@0.2.0