### PR TITLE
Return field value from useSpy

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,9 @@ export interface FormHookContext {
   validate: () => object;
   values: Values;
 }
+
+export interface FieldInformation<T> {
+  error: string;
+  touched: boolean;
+  value: T;
+}

--- a/src/useField.ts
+++ b/src/useField.ts
@@ -1,4 +1,5 @@
 import { get } from './helpers/operations';
+import { FieldInformation } from './types';
 import { useContextEmitter } from './useContextEmitter';
 
 export interface FieldOperations<T> {
@@ -7,29 +8,28 @@ export interface FieldOperations<T> {
   onFocus: () => void;
 }
 
-export interface FieldInformation<T> {
-  error: string;
-  touched: boolean;
-  value: T;
-}
-
 export default function useField<T = any>(
-  fieldId: string,
+  fieldId: string
 ): [FieldOperations<T>, FieldInformation<T>] {
-  if (process.env.NODE_ENV !== 'production' && (!fieldId || typeof fieldId !== 'string')) {
-    throw new Error('The Field needs a valid "fieldId" property to function correctly.');
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    (!fieldId || typeof fieldId !== 'string')
+  ) {
+    throw new Error(
+      'The Field needs a valid "fieldId" property to function correctly.'
+    );
   }
 
   const ctx = useContextEmitter(fieldId);
   return [
     {
-      onBlur:() => {
+      onBlur: () => {
         ctx.setFieldTouched(fieldId, true);
       },
-      onChange:(value: T) => {
+      onChange: (value: T) => {
         ctx.setFieldValue(fieldId, value);
       },
-      onFocus:() => {
+      onFocus: () => {
         ctx.setFieldTouched(fieldId, false);
       },
     },

--- a/src/useSpy.ts
+++ b/src/useSpy.ts
@@ -3,13 +3,20 @@ import { get } from './helpers/operations';
 import { FormHookContext } from './types';
 import { useContextEmitter } from './useContextEmitter';
 
-const useSpy = (fieldId: string, cb: (newValue: any, ctx: FormHookContext) => void) => {
+const useSpy = (
+  fieldId: string,
+  cb: (newValue: any, ctx: FormHookContext) => void
+) => {
   const isMounted = React.useRef<undefined | boolean>();
   const ctx = useContextEmitter(fieldId);
+  const value = get(ctx.values, fieldId);
+
   React.useEffect(() => {
-    if (isMounted.current) cb(get(ctx.values, fieldId), ctx);
+    if (isMounted.current) cb(value, ctx);
     isMounted.current = true;
-  }, [get(ctx.values, fieldId)]);
+  }, [value]);
+
+  return { value };
 };
 
 export default useSpy;

--- a/src/useSpy.ts
+++ b/src/useSpy.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { get } from './helpers/operations';
-import { FormHookContext } from './types';
+import { FieldInformation, FormHookContext } from './types';
 import { useContextEmitter } from './useContextEmitter';
 
 export type SpyCallback<T> = (newValue: T, ctx: FormHookContext) => void;
@@ -8,7 +8,7 @@ export type SpyCallback<T> = (newValue: T, ctx: FormHookContext) => void;
 export default function useSpy<T = any>(
   fieldId: string,
   cb?: SpyCallback<T>
-): [T, FormHookContext] {
+): FieldInformation<T> {
   const isMounted = React.useRef<boolean>(false);
   const ctx = useContextEmitter(fieldId);
   const value = get(ctx.values, fieldId);
@@ -18,5 +18,9 @@ export default function useSpy<T = any>(
     isMounted.current = true;
   }, [value]);
 
-  return [value, ctx];
+  return {
+    error: get(ctx.errors, fieldId),
+    touched: get(ctx.touched, fieldId),
+    value,
+  };
 }

--- a/src/useSpy.ts
+++ b/src/useSpy.ts
@@ -3,20 +3,20 @@ import { get } from './helpers/operations';
 import { FormHookContext } from './types';
 import { useContextEmitter } from './useContextEmitter';
 
-const useSpy = (
+export type SpyCallback<T> = (newValue: T, ctx: FormHookContext) => void;
+
+export default function useSpy<T = any>(
   fieldId: string,
-  cb: (newValue: any, ctx: FormHookContext) => void
-) => {
-  const isMounted = React.useRef<undefined | boolean>();
+  cb?: SpyCallback<T>
+): [T, FormHookContext] {
+  const isMounted = React.useRef<boolean>(false);
   const ctx = useContextEmitter(fieldId);
   const value = get(ctx.values, fieldId);
 
   React.useEffect(() => {
-    if (isMounted.current) cb(value, ctx);
+    if (isMounted.current && cb) cb(value, ctx);
     isMounted.current = true;
   }, [value]);
 
-  return { value };
-};
-
-export default useSpy;
+  return [value, ctx];
+}


### PR DESCRIPTION
Changes the return value of `useSpy` from `void` to an object containing the field's value

### Motivation

I had a use case like this (simplified):

```js
const MaxLengthSpy = ({ fieldId, maxLength }) => {
  useSpy(fieldId, (value: string, { setFieldError }) => {
    if (value.length > maxLength) {
      setFieldError(fieldId, 'too long')
    }
  })

  return (
    <Flex justify='flex-end'>
      <Text color='grey50' size={0.75}>
        {/* whats the current length? */} / {maxLength}
      </Text>
    </Flex>
  )
}
```

Seems logical that `useSpy` could return the value, since it would need it to invoke the callback

### v5 / Large minor patch ideas

Getting a `FormHookContext` update only when a specific field changes is a great concept. The alternative of `useFormConnect` is inefficient and clumsy. Unfortunately, in its current state, `useSpy` is very limiting.

It would be great if `useSpy` could just return the context value, instead of passing it to a callback. This allows `useSpy` to truly be a more efficient `useFormConnect` instead.

As far as I can tell, there would be no drawbacks to this approach (besides API changes). The hook is connected to the context anyways, and current behavior could be achieved simply by using built-in React hooks.

If you prefer this idea, I can replace this PR with one that achieves this with new tests, etc. Could be achieved in v4 with a deprecation notice for `useSpy`s second argument