### PR TITLE
Add html form props type

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -34,7 +34,8 @@ export interface Payload {
   resetForm: () => void;
 }
 
-export interface FormOptions<T> {
+export interface FormOptions<T>
+  extends Omit<React.HTMLProps<HTMLFormElement>, 'onSubmit' | 'onError'> {
   children?: ((form: Payload) => React.ReactNode) | React.ReactNode;
   enableReinitialize?: boolean;
   initialErrors?: Errors;


### PR DESCRIPTION
I added the types of the html form to the `Form` component so the props injected to the native `form` element are type-checked.

I'm not sure I've implemented it the best way so don't hesitate if you think of any improvements :)

