### PR TITLE
Improve typings

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -3,7 +3,7 @@ import { emit } from './context/emitter';
 import { deriveInitial } from './helpers/deriveInitial';
 import { deriveKeys } from './helpers/deriveKeys';
 import useState, { EMPTY_OBJ } from './helpers/useState';
-import { Errors, FormHookContext, InitialValues, Touched } from './types';
+import { Errors, FormHookContext, Touched } from './types';
 
 export const formContext = React.createContext<FormHookContext>(
   null as any,
@@ -39,13 +39,13 @@ export interface FormOptions<T>
   children?: ((form: Payload) => React.ReactNode) | React.ReactNode;
   enableReinitialize?: boolean;
   initialErrors?: Errors;
-  initialValues?: InitialValues;
+  initialValues?: Partial<T>;
   noForm?: boolean;
   onError?: (error: object, callbag: ErrorBag) => void;
   onSuccess?: (result: any, callbag: SuccessBag) => void;
   onSubmit: (values: Partial<T>, callbag: CallBag) => Promise<any> | any;
   shouldSubmitWhenInvalid?: boolean;
-  validate?: (values: Partial<T>) => object;
+  validate?: (values: Partial<T>) => object | undefined;
   validateOnBlur?: boolean;
   validateOnChange?: boolean;
 }

--- a/src/FormHoc.tsx
+++ b/src/FormHoc.tsx
@@ -1,23 +1,21 @@
 import * as React from 'react';
 import Form, { FormOptions } from './Form';
-import { InitialValues } from './types';
-import { useContextEmitter } from './useContextEmitter';
 
-type FormHocOptions<T> = FormOptions<T> & {
-  mapPropsToValues?: (props: object) => InitialValues;
+type FormHocOptions<T, P> = FormOptions<T> & {
+  mapPropsToValues?: (props: P) => Partial<T>;
 };
 
-const OptionsContainer = <Values extends object>({
+const OptionsContainer = <Values extends object, Props extends object>({
   enableReinitialize,
   mapPropsToValues,
   ...rest
-}: FormHocOptions<Values>) => {
+}: FormHocOptions<Values, Props>) => {
   let isMounted = false;
 
   return function FormOuterWrapper(
     Component: React.ComponentType<any> | React.FC<any>
   ) {
-    return function FormWrapper(props: { [property: string]: any }) {
+    return function FormWrapper(props: Props) {
       const { 0: initialValues, 1: setInitialValues } = React.useState(() =>
         mapPropsToValues ? mapPropsToValues(props) : rest.initialValues
       );

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,10 +10,6 @@ export interface Errors {
   [fieldId: string]: string | Array<Errors>;
 }
 
-export interface InitialValues {
-  [fieldId: string]: any;
-}
-
 export interface FormHookContext {
   errors: Errors;
   isDirty?: boolean;


### PR DESCRIPTION
This adds the Props generic and strictly types the `initialValues` and `mapPropsToValues` currently looking for a way to type touched and errors as `keyof (valuesGeneric): boolean....`