### PR TITLE
HookedForm: forwardRef

### DIFF
--- a/__tests__/components/Form.test.tsx
+++ b/__tests__/components/Form.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, cleanup, render, wait } from '@testing-library/react';
+import { act, cleanup, render } from '@testing-library/react';
 import { HookedForm, useFormConnect } from '../../src';
 
 const Component = () => <p>Hi</p>;
@@ -49,6 +49,16 @@ describe('HookedForm', () => {
   it('should render child element', () => {
     const { container } = makeHookedForm();
     expect(container.firstChild).toBeDefined();
+  });
+
+  it('should forward ref', () => {
+    const ref = React.createRef<HTMLFormElement>();
+    const { getByTestId } = makeHookedForm({
+      ref,
+      ['data-testid']: 'myForm',
+    });
+
+    expect(getByTestId('myForm')).toBe(ref.current);
   });
 
   it('Changes when calling change', () => {

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -51,21 +51,24 @@ export interface FormOptions<T>
   validateOnChange?: boolean;
 }
 
-const Form = <Values extends object>({
-  children,
-  enableReinitialize,
-  initialErrors,
-  initialValues,
-  onSubmit,
-  noForm,
-  validate,
-  onError,
-  onSuccess,
-  shouldSubmitWhenInvalid,
-  validateOnBlur,
-  validateOnChange,
-  ...formProps // used to inject className, onKeyDown and related on the <form>
-}: FormOptions<Values>) => {
+const Form = <Values extends object>(
+  {
+    children,
+    enableReinitialize,
+    initialErrors,
+    initialValues,
+    onSubmit,
+    noForm,
+    validate,
+    onError,
+    onSuccess,
+    shouldSubmitWhenInvalid,
+    validateOnBlur,
+    validateOnChange,
+    ...formProps // used to inject className, onKeyDown and related on the <form>
+  }: FormOptions<Values>,
+  innerRef: React.Ref<HTMLFormElement>
+) => {
   const fieldValidators = React.useRef<ValidationTuple[]>([]);
   const isDirty = React.useRef(false);
 
@@ -242,7 +245,7 @@ const Form = <Values extends object>({
       {noForm ? (
         toRender
       ) : (
-        <form onSubmit={handleSubmit} {...formProps}>
+        <form onSubmit={handleSubmit} {...formProps} ref={innerRef}>
           {toRender}
         </form>
       )}
@@ -250,4 +253,6 @@ const Form = <Values extends object>({
   );
 };
 
-export default Form;
+export default React.forwardRef(Form) as <Values extends Record<string, any>>(
+  props: FormOptions<Values>
+) => JSX.Element;


### PR DESCRIPTION
Add forwardRef to HookedForm.

I used the same technique as described here: https://github.com/kripod/react-polymorphic-box#forwarding-refs

There's also an open PR on the formik repo https://github.com/jaredpalmer/formik/pull/2222 which do the same. It's not ideal since it uses a cast but from what I've read, there's no better way to achieve it for the moment.

Up to you to decide if you want to get this or if you prefer to wait for a possible better solution in the future :)

